### PR TITLE
Correction bug, mismatch between position X and Y in method avancer and reculer

### DIFF
--- a/dotnet/mission-to-mars/Rover.cs
+++ b/dotnet/mission-to-mars/Rover.cs
@@ -31,8 +31,8 @@ namespace mission_to_mars
             {
                 Direction.NORD => Position with { Y = Position.Y + 1 },
                 Direction.SUD => Position with { Y = Position.Y - 1 },
-                Direction.EST => Position with { X = Position.Y + 1 },
-                _ => Position with { X = Position.Y - 1 },
+                Direction.OUEST => Position with { X = Position.X - 1 },
+                _ => Position with { X = Position.X + 1 },
             };
         }
 
@@ -43,8 +43,8 @@ namespace mission_to_mars
             {
                 Direction.NORD => Position with { Y = Position.Y - 1 },
                 Direction.SUD => Position with { Y = Position.Y + 1 },
-                Direction.EST => Position with { X = Position.Y - 1 },
-                _ => Position with { X = Position.Y + 1 },
+                Direction.OUEST => Position with { X = Position.X + 1 },
+                _ => Position with { X = Position.X - 1 },
             };
         }
 


### PR DESCRIPTION
I aligned the directions in the switch/case to match with the java version, too.